### PR TITLE
Added text (faking it, pre-rendered to a textures)

### DIFF
--- a/shaders/guiFrag.glsl
+++ b/shaders/guiFrag.glsl
@@ -2,6 +2,8 @@
 
 uniform float aspect;
 uniform vec3 rgb;
+uniform float texAlpha;
+uniform sampler2D tex;
 
 in vec2 center;
 in vec2 scale;
@@ -49,6 +51,10 @@ void main()
     if(dist > 1 || dist < minDist){
         discard;
     }
-    color = vec4(rgb, 1);
-
+    if(texAlpha < 0){
+        color = vec4(rgb, 1);
+    }else{
+        //color = vec4(1, 0, 0, 1);
+        color = texture(tex, geomPos * 0.8f + vec2(0.5f)) * texAlpha;
+    }
 }

--- a/src/GuiRenderPass.h
+++ b/src/GuiRenderPass.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "IShader.h"
 #include "Program.h"
+#include "Texture.h"
 
 #include <memory>
 
@@ -18,6 +19,9 @@ private:
     GLuint vaoID;
 
     std::shared_ptr<Program> prog;
+    Texture winTex;
+    Texture startTex;
+    Texture deathTex;
 
     void setGeometry(int lives, int points, float distToGoal);
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,6 +187,9 @@ public:
 		rp.addRenderPass(std::make_shared<BloomRenderPass>());
 		rp.addRenderPass(std::make_shared<LazerGlowRenderPass>());
 		rp.addRenderPass(std::make_shared<GuiRenderPass>());
+		rm->addNumericalValue("guiStartTime", -1.0f);
+		rm->addNumericalValue("guiWinTime", -1.0f);
+		rm->addNumericalValue("guiDeathTime", -1.0f);
 		// add render passes with more shaders here
 	}
 


### PR DESCRIPTION
Text works. For death and winning it isn't triggered yet, because the text needs to show up after the animations.
When it's ready to display the death text we need to do:
`rm->addNumericalValue("guiDeathTime", time);`
And when it's ready to display the win text we need to do:
`rm->addNumericalValue("guiWinTime", time);`
Where `rm` is the ResourceManager's instance and `time` is equivalent to `Time::getInstance()->getGlobalTime()`